### PR TITLE
Read commits from default branch

### DIFF
--- a/src/views/github.py
+++ b/src/views/github.py
@@ -72,11 +72,24 @@ def map_commit(c, i = 0):
         "parents": [p["sha"] for p in c["parents"]],
     }
 
+async def get_default_branch(repo_path, github_token):
+    headers = {"Authorization": f"token {github_token}"}
+
+    repo_info_endpoint = f"https://api.github.com/repos/{repo_path}"
+    logger.info(f'Retrieving repository information from Github via "{repo_info_endpoint}"...')
+
+    repo_info_request = await httpx.get(repo_info_endpoint, headers=headers)
+    repo_info = repo_info_request.json()
+
+    return repo_info.get('default_branch', 'master')
+
 async def get_all_commits(repo_path, github_token):
+    default_branch = await get_default_branch(repo_path, github_token)
+
     headers = {"Authorization": f"token {github_token}"}
 
     initial_page = (
-        f"https://api.github.com/repos/{repo_path}/commits?sha=master&per_page=100"
+        f"https://api.github.com/repos/{repo_path}/commits?sha={default_branch}&per_page=100"
     )
 
     logger.info(f'Retrieving commits from Github via "{initial_page}"...')

--- a/src/views/github.py
+++ b/src/views/github.py
@@ -115,7 +115,7 @@ async def get_all_commits(repo_path, github_token):
 
             for i in range(0, concurrent_pages):
                 request = httpx.get(
-                    f"https://api.github.com/repos/{repo_path}/commits?sha=master&per_page=100&page={current_page}",
+                    f"https://api.github.com/repos/{repo_path}/commits?sha={default_branch}&per_page=100&page={current_page}",
                     headers=headers,
                 )
 


### PR DESCRIPTION
Instead of retrieving commits from `master` branch, it asks github first which is the default branch, then retrieve commits from it.